### PR TITLE
allows toolRuntimeConfig in rendering-info/html-static endpoint

### DIFF
--- a/routes/rendering-info/html-static.js
+++ b/routes/rendering-info/html-static.js
@@ -16,7 +16,8 @@ module.exports = {
   config: {
     validate: {
       payload: {
-        item: schema
+        item: schema,
+        toolRuntimeConfig: Joi.object()
       }
     },
   },


### PR DESCRIPTION
This should work if `toolRuntimeConfig` is given and if it is missing.